### PR TITLE
Publish docs from GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <packaging>hpi</packaging>
 
     <name>Additional Metrics Plugin</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Additional+Metrics+Plugin</url>
+    <url>https://github.com/jenkinsci/additional-metrics-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
See [1](https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/) and [2](https://www.jenkins.io/doc/developer/publishing/wiki-page/). 