### PR TITLE
Use upstream Spotless configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,189 +23,151 @@
   ~ SOFTWARE.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>4.59</version>
-    </parent>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.59</version>
+  </parent>
 
-    <artifactId>additional-metrics</artifactId>
-    <version>${changelist}</version>
-    <packaging>hpi</packaging>
+  <artifactId>additional-metrics</artifactId>
+  <version>${changelist}</version>
+  <packaging>hpi</packaging>
+  <name>Additional Metrics Plugin</name>
+  <url>https://github.com/jenkinsci/additional-metrics-plugin</url>
+  <inceptionYear>2018</inceptionYear>
 
-    <name>Additional Metrics Plugin</name>
-    <url>https://github.com/jenkinsci/additional-metrics-plugin</url>
+  <organization>
+    <name>Chadi El Masri</name>
+  </organization>
 
-    <inceptionYear>2018</inceptionYear>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+  </licenses>
 
-    <organization>
-        <name>Chadi El Masri</name>
-    </organization>
+  <developers>
+    <developer>
+      <id>chadiem</id>
+      <name>Chadi El Masri</name>
+      <email>chadimsr@gmail.com</email>
+    </developer>
+    <developer>
+      <id>dainerx</id>
+      <name>Oussama Ben Ghorbel</name>
+      <email>d.oussamabenghorbel@gmail.com</email>
+    </developer>
+  </developers>
 
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>https://opensource.org/licenses/MIT</url>
-        </license>
-    </licenses>
+  <scm>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
+  </scm>
 
-    <developers>
-        <developer>
-            <id>chadiem</id>
-            <name>Chadi El Masri</name>
-            <email>chadimsr@gmail.com</email>
-        </developer>
-        <developer>
-            <id>dainerx</id>
-            <name>Oussama Ben Ghorbel</name>
-            <email>d.oussamabenghorbel@gmail.com</email>
-        </developer>
-    </developers>
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/additional-metrics-plugin</gitHubRepo>
+    <jenkins.version>2.361.4</jenkins.version>
+    <spotbugs.effort>Max</spotbugs.effort>
+  </properties>
 
-    <scm>
-        <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-        <tag>${scmTag}</tag>
-        <url>https://github.com/${gitHubRepo}</url>
-    </scm>
-
-    <properties>
-        <changelist>999999-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/additional-metrics-plugin</gitHubRepo>
-        <jenkins.version>2.361.4</jenkins.version>
-        <spotbugs.effort>Max</spotbugs.effort>
-        <spotless.version>2.36.0</spotless.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>1981.v17df70e84a_a_1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.10.2</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>1981.v17df70e84a_a_1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>${spotless.version}</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <formats>
-                        <format>
-                            <includes>
-                                <include>src/main/java/**/*.java</include>
-                                <include>src/test/java/**/*.java</include>
-                                <include>src/main/resources/**/*.jelly</include>
-                                <include>.gitignore</include>
-                            </includes>
-                            <trimTrailingWhitespace/>
-                            <endWithNewline/>
-                            <indent>
-                                <spaces>true</spaces>
-                            </indent>
-                        </format>
-                    </formats>
-                    <java>
-                        <removeUnusedImports/>
-                        <formatAnnotations/>
-                        <licenseHeader>
-                            <file>${project.basedir}/.java-license-header</file>
-                        </licenseHeader>
-                    </java>
-                    <pom>
-                        <sortPom>
-                            <nrOfIndentSpace>4</nrOfIndentSpace>
-                            <sortDependencies>scope</sortDependencies>
-                            <lineSeparator>\n</lineSeparator>
-                            <expandEmptyElements>false</expandEmptyElements>
-                        </sortPom>
-                    </pom>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <java combine.children="append">
+            <licenseHeader>
+              <file>${project.basedir}/.java-license-header</file>
+            </licenseHeader>
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/AdditionalMetricColumnDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/AdditionalMetricColumnDescriptor.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.additionalmetrics;
 
 import hudson.views.ListViewColumnDescriptor;
-
 import javax.annotation.Nonnull;
 
 abstract class AdditionalMetricColumnDescriptor extends ListViewColumnDescriptor {

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/AvgCheckoutDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/AvgCheckoutDurationColumn.java
@@ -24,16 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_CHECKOUT_DURATION;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.averageDuration;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_CHECKOUT_DURATION;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.averageDuration;
 
 public class AvgCheckoutDurationColumn extends ListViewColumn {
 
@@ -44,11 +44,8 @@ public class AvgCheckoutDurationColumn extends ListViewColumn {
 
     @Metric
     public Duration getAverageCheckoutDuration(Job<? extends Job, ? extends Run> job) {
-        return averageDuration(
-                job.getBuilds(),
-                COMPLETED,
-                RUN_CHECKOUT_DURATION
-        ).orElse(null);
+        return averageDuration(job.getBuilds(), COMPLETED, RUN_CHECKOUT_DURATION)
+                .orElse(null);
     }
 
     @Extension
@@ -58,7 +55,5 @@ public class AvgCheckoutDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.AvgCheckoutDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/AvgDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/AvgDurationColumn.java
@@ -24,16 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.averageDuration;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.averageDuration;
 
 public class AvgDurationColumn extends ListViewColumn {
 
@@ -44,11 +44,7 @@ public class AvgDurationColumn extends ListViewColumn {
 
     @Metric
     public Duration getAverageDuration(Job<? extends Job, ? extends Run> job) {
-        return averageDuration(
-                job.getBuilds(),
-                COMPLETED,
-                RUN_DURATION
-        ).orElse(null);
+        return averageDuration(job.getBuilds(), COMPLETED, RUN_DURATION).orElse(null);
     }
 
     @Extension
@@ -58,7 +54,5 @@ public class AvgDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.AvgDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/AvgSuccessDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/AvgSuccessDurationColumn.java
@@ -24,16 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.averageDuration;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.averageDuration;
 
 public class AvgSuccessDurationColumn extends ListViewColumn {
 
@@ -44,11 +44,7 @@ public class AvgSuccessDurationColumn extends ListViewColumn {
 
     @Metric
     public Duration getAverageSuccessDuration(Job<? extends Job, ? extends Run> job) {
-        return averageDuration(
-                job.getBuilds(),
-                SUCCESS,
-                RUN_DURATION
-        ).orElse(null);
+        return averageDuration(job.getBuilds(), SUCCESS, RUN_DURATION).orElse(null);
     }
 
     @Extension
@@ -58,7 +54,5 @@ public class AvgSuccessDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.AvgSuccessDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/CheckoutDuration.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/CheckoutDuration.java
@@ -43,9 +43,7 @@ class CheckoutDuration {
 
     static long checkoutDurationOf(Run run) {
         Jenkins instance = Jenkins.getInstanceOrNull();
-        if (instance != null
-                && instance.getPlugin("workflow-job") != null
-                && run instanceof WorkflowRun) {
+        if (instance != null && instance.getPlugin("workflow-job") != null && run instanceof WorkflowRun) {
             WorkflowRun currentBuild = (WorkflowRun) run;
             FlowExecution execution = currentBuild.getExecution();
             if (execution != null) {
@@ -73,5 +71,4 @@ class CheckoutDuration {
 
         return totalCheckoutTime;
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/Duration.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/Duration.java
@@ -40,5 +40,4 @@ public class Duration {
     public String getAsString() {
         return Util.getTimeSpanString(milliseconds);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/FailureRateColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/FailureRateColumn.java
@@ -24,16 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.NOT_SUCCESS;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.rateOf;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.NOT_SUCCESS;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.rateOf;
 
 public class FailureRateColumn extends ListViewColumn {
 
@@ -44,11 +44,7 @@ public class FailureRateColumn extends ListViewColumn {
 
     @Metric
     public Rate getFailureRate(Job<? extends Job, ? extends Run> job) {
-        return rateOf(
-                job.getBuilds(),
-                COMPLETED,
-                NOT_SUCCESS
-        ).orElse(null);
+        return rateOf(job.getBuilds(), COMPLETED, NOT_SUCCESS).orElse(null);
     }
 
     @Extension
@@ -58,7 +54,5 @@ public class FailureRateColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.FailureRateColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/FailureTimeRateColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/FailureTimeRateColumn.java
@@ -24,16 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.NOT_SUCCESS;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.timeRateOf;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.NOT_SUCCESS;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.timeRateOf;
 
 public class FailureTimeRateColumn extends ListViewColumn {
 
@@ -44,11 +44,7 @@ public class FailureTimeRateColumn extends ListViewColumn {
 
     @Metric
     public Rate getFailureTimeRate(Job<? extends Job, ? extends Run> job) {
-        return timeRateOf(
-                job.getBuilds(),
-                COMPLETED,
-                NOT_SUCCESS
-        ).orElse(null);
+        return timeRateOf(job.getBuilds(), COMPLETED, NOT_SUCCESS).orElse(null);
     }
 
     @Extension
@@ -58,7 +54,5 @@ public class FailureTimeRateColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.FailureTimeRateColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/Helpers.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/Helpers.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.additionalmetrics;
 
 import hudson.model.Result;
 import hudson.model.Run;
-
 import java.util.Comparator;
 import java.util.function.BinaryOperator;
 import java.util.function.Predicate;
@@ -41,7 +40,8 @@ class Helpers {
     static final Predicate<Run> NOT_SUCCESS = SUCCESS.negate();
     static final Predicate<Run> COMPLETED = run -> !run.isBuilding();
 
-    private static final Comparator<RunWithDuration> DURATION_ORDERING = Comparator.comparing(runWithDuration -> runWithDuration.getDuration().getAsLong());
+    private static final Comparator<RunWithDuration> DURATION_ORDERING = Comparator.comparing(
+            runWithDuration -> runWithDuration.getDuration().getAsLong());
 
     static final BinaryOperator<RunWithDuration> MIN = BinaryOperator.minBy(DURATION_ORDERING);
     static final BinaryOperator<RunWithDuration> MAX = BinaryOperator.maxBy(DURATION_ORDERING);
@@ -49,6 +49,4 @@ class Helpers {
     private Helpers() {
         // utility class
     }
-
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/JobMetrics.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/JobMetrics.java
@@ -187,5 +187,4 @@ public class JobMetrics {
 
         return 0;
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MathCommons.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MathCommons.java
@@ -36,8 +36,7 @@ import java.util.stream.DoubleStream;
  */
 public final class MathCommons {
 
-    private MathCommons() {
-    }
+    private MathCommons() {}
 
     /**
      * @param list elements
@@ -57,11 +56,9 @@ public final class MathCommons {
         return standardDeviationDouble(() -> list.stream().mapToDouble(t -> t.doubleValue()));
     }
 
-
     private static OptionalDouble averageDouble(Supplier<DoubleStream> streamSupplier) {
         OptionalDouble average = streamSupplier.get().average();
-        if (!average.isPresent())
-            return OptionalDouble.empty();
+        if (!average.isPresent()) return OptionalDouble.empty();
         return average;
     }
 
@@ -71,7 +68,9 @@ public final class MathCommons {
             return OptionalDouble.empty();
         } else {
             // Given the stream consumed is a finite sequence, if a mean is present, std follows.
-            double variance = streamSupplier.get().map(d -> d - mean.getAsDouble())
+            double variance = streamSupplier
+                    .get()
+                    .map(d -> d - mean.getAsDouble())
                     .map(d -> d * d)
                     .average()
                     .getAsDouble();

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MaxCheckoutDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MaxCheckoutDurationColumn.java
@@ -24,15 +24,15 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
 
 public class MaxCheckoutDurationColumn extends ListViewColumn {
 
@@ -43,12 +43,7 @@ public class MaxCheckoutDurationColumn extends ListViewColumn {
 
     @Metric
     public RunWithDuration getLongestCheckoutRun(Job<? extends Job, ? extends Run> job) {
-        return findRun(
-                job.getBuilds(),
-                COMPLETED,
-                RUN_CHECKOUT_DURATION,
-                MAX
-        ).orElse(null);
+        return findRun(job.getBuilds(), COMPLETED, RUN_CHECKOUT_DURATION, MAX).orElse(null);
     }
 
     @Extension
@@ -58,7 +53,5 @@ public class MaxCheckoutDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.MaxCheckoutDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MaxDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MaxDurationColumn.java
@@ -24,15 +24,15 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
 
 public class MaxDurationColumn extends ListViewColumn {
 
@@ -43,12 +43,7 @@ public class MaxDurationColumn extends ListViewColumn {
 
     @Metric
     public RunWithDuration getLongestRun(Job<? extends Job, ? extends Run> job) {
-        return findRun(
-                job.getBuilds(),
-                COMPLETED,
-                RUN_DURATION,
-                MAX
-        ).orElse(null);
+        return findRun(job.getBuilds(), COMPLETED, RUN_DURATION, MAX).orElse(null);
     }
 
     @Extension
@@ -58,7 +53,5 @@ public class MaxDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.MaxDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MaxSuccessDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MaxSuccessDurationColumn.java
@@ -24,15 +24,15 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
 
 public class MaxSuccessDurationColumn extends ListViewColumn {
 
@@ -43,12 +43,7 @@ public class MaxSuccessDurationColumn extends ListViewColumn {
 
     @Metric
     public RunWithDuration getLongestSuccessfulRun(Job<? extends Job, ? extends Run> job) {
-        return findRun(
-                job.getBuilds(),
-                SUCCESS,
-                RUN_DURATION,
-                MAX
-        ).orElse(null);
+        return findRun(job.getBuilds(), SUCCESS, RUN_DURATION, MAX).orElse(null);
     }
 
     @Extension
@@ -58,7 +53,5 @@ public class MaxSuccessDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.MaxSuccessDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/Metric.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/Metric.java
@@ -24,5 +24,4 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
-public @interface Metric {
-}
+public @interface Metric {}

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MetricsActionFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MetricsActionFactory.java
@@ -27,13 +27,12 @@ package org.jenkinsci.plugins.additionalmetrics;
 import hudson.Extension;
 import hudson.model.Action;
 import hudson.model.Job;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Nonnull;
 import jenkins.model.TransientActionFactory;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
-import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.Collections;
 
 @Extension
 public class MetricsActionFactory extends TransientActionFactory<Job> {

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MinCheckoutDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MinCheckoutDurationColumn.java
@@ -24,14 +24,14 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
 
 public class MinCheckoutDurationColumn extends ListViewColumn {
 
@@ -42,12 +42,8 @@ public class MinCheckoutDurationColumn extends ListViewColumn {
 
     @Metric
     public RunWithDuration getShortestCheckoutRun(Job<? extends Job, ? extends Run> job) {
-        return Utils.findRun(
-                job.getBuilds(),
-                COMPLETED,
-                RUN_CHECKOUT_DURATION,
-                MIN
-        ).orElse(null);
+        return Utils.findRun(job.getBuilds(), COMPLETED, RUN_CHECKOUT_DURATION, MIN)
+                .orElse(null);
     }
 
     @Extension
@@ -57,7 +53,5 @@ public class MinCheckoutDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.MinCheckoutDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MinDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MinDurationColumn.java
@@ -24,15 +24,15 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
 
 public class MinDurationColumn extends ListViewColumn {
 
@@ -43,12 +43,7 @@ public class MinDurationColumn extends ListViewColumn {
 
     @Metric
     public RunWithDuration getShortestRun(Job<? extends Job, ? extends Run> job) {
-        return findRun(
-                job.getBuilds(),
-                COMPLETED,
-                RUN_DURATION,
-                MIN
-        ).orElse(null);
+        return findRun(job.getBuilds(), COMPLETED, RUN_DURATION, MIN).orElse(null);
     }
 
     @Extension
@@ -58,7 +53,5 @@ public class MinDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.MinDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/MinSuccessDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/MinSuccessDurationColumn.java
@@ -24,15 +24,15 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.*;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.findRun;
 
 public class MinSuccessDurationColumn extends ListViewColumn {
 
@@ -43,12 +43,7 @@ public class MinSuccessDurationColumn extends ListViewColumn {
 
     @Metric
     public RunWithDuration getShortestSuccessfulRun(Job<? extends Job, ? extends Run> job) {
-        return findRun(
-                job.getBuilds(),
-                SUCCESS,
-                RUN_DURATION,
-                MIN
-        ).orElse(null);
+        return findRun(job.getBuilds(), SUCCESS, RUN_DURATION, MIN).orElse(null);
     }
 
     @Extension
@@ -58,7 +53,5 @@ public class MinSuccessDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.MinSuccessDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/StdevDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/StdevDurationColumn.java
@@ -24,14 +24,15 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.stdDevDuration;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.stdDevDuration;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class StdevDurationColumn extends ListViewColumn {
@@ -52,7 +53,5 @@ public class StdevDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.StdevDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/StdevSuccessDurationColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/StdevSuccessDurationColumn.java
@@ -24,14 +24,15 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.stdDevDuration;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.RUN_DURATION;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.stdDevDuration;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class StdevSuccessDurationColumn extends ListViewColumn {
@@ -42,11 +43,7 @@ public class StdevSuccessDurationColumn extends ListViewColumn {
 
     @Metric
     public Duration getStdevSuccessDuration(Job<? extends Job, ? extends Run> job) {
-        return stdDevDuration(
-                job.getBuilds(),
-                SUCCESS,
-                RUN_DURATION
-        ).orElse(null);
+        return stdDevDuration(job.getBuilds(), SUCCESS, RUN_DURATION).orElse(null);
     }
 
     @Extension
@@ -56,7 +53,5 @@ public class StdevSuccessDurationColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.StdevSuccessDurationColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/SuccessRateColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/SuccessRateColumn.java
@@ -24,16 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.rateOf;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.rateOf;
 
 public class SuccessRateColumn extends ListViewColumn {
 
@@ -44,11 +44,7 @@ public class SuccessRateColumn extends ListViewColumn {
 
     @Metric
     public Rate getSuccessRate(Job<? extends Job, ? extends Run> job) {
-        return rateOf(
-                job.getBuilds(),
-                COMPLETED,
-                SUCCESS
-        ).orElse(null);
+        return rateOf(job.getBuilds(), COMPLETED, SUCCESS).orElse(null);
     }
 
     @Extension
@@ -58,7 +54,5 @@ public class SuccessRateColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.SuccessRateColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/SuccessTimeRateColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/SuccessTimeRateColumn.java
@@ -24,16 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
+import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
+import static org.jenkinsci.plugins.additionalmetrics.Utils.timeRateOf;
+
 import hudson.Extension;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.views.ListViewColumn;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.COMPLETED;
-import static org.jenkinsci.plugins.additionalmetrics.Helpers.SUCCESS;
-import static org.jenkinsci.plugins.additionalmetrics.Utils.timeRateOf;
 
 public class SuccessTimeRateColumn extends ListViewColumn {
 
@@ -44,11 +44,7 @@ public class SuccessTimeRateColumn extends ListViewColumn {
 
     @Metric
     public Rate getSuccessTimeRate(Job<? extends Job, ? extends Run> job) {
-        return timeRateOf(
-                job.getBuilds(),
-                COMPLETED,
-                SUCCESS
-        ).orElse(null);
+        return timeRateOf(job.getBuilds(), COMPLETED, SUCCESS).orElse(null);
     }
 
     @Extension
@@ -58,7 +54,5 @@ public class SuccessTimeRateColumn extends ListViewColumn {
         public DescriptorImpl() {
             super(Messages.SuccessTimeRateColumn_DisplayName());
         }
-
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/additionalmetrics/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/additionalmetrics/Utils.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.additionalmetrics;
 
 import com.google.common.collect.Iterables;
 import hudson.model.Run;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
@@ -45,8 +44,7 @@ class Utils {
     }
 
     static Optional<Rate> rateOf(List<? extends Run> runs, Predicate<Run> preFilter, Predicate<Run> predicateRate) {
-        List<? extends Run> filteredRuns = preFilter(runs, preFilter)
-                .collect(Collectors.toList());
+        List<? extends Run> filteredRuns = preFilter(runs, preFilter).collect(Collectors.toList());
 
         if (filteredRuns.isEmpty()) {
             return Optional.empty();
@@ -66,8 +64,7 @@ class Utils {
     }
 
     static Optional<Rate> timeRateOf(List<? extends Run> runs, Predicate<Run> preFilter, Predicate<Run> predicateRate) {
-        List<? extends Run> filteredRuns = preFilter(runs, preFilter)
-                .collect(Collectors.toList());
+        List<? extends Run> filteredRuns = preFilter(runs, preFilter).collect(Collectors.toList());
 
         if (filteredRuns.isEmpty()) {
             return Optional.empty();
@@ -93,22 +90,36 @@ class Utils {
         return Optional.of(new Rate((double) accumulatedPredicateTime / (endTime - startTime)));
     }
 
-    static Optional<RunWithDuration> findRun(List<? extends Run> runs, Predicate<Run> preFilter, ToLongFunction<Run> durationFunction, BinaryOperator<RunWithDuration> operator) {
+    static Optional<RunWithDuration> findRun(
+            List<? extends Run> runs,
+            Predicate<Run> preFilter,
+            ToLongFunction<Run> durationFunction,
+            BinaryOperator<RunWithDuration> operator) {
         return preFilter(runs, preFilter)
                 .filter(r -> durationFunction.applyAsLong(r) > 0)
                 .map(r -> new RunWithDuration(r, new Duration(durationFunction.applyAsLong(r))))
                 .reduce(operator);
     }
 
-    static Optional<Duration> averageDuration(List<? extends Run> runs, Predicate<Run> preFilter, ToLongFunction<Run> durationFunction) {
+    static Optional<Duration> averageDuration(
+            List<? extends Run> runs, Predicate<Run> preFilter, ToLongFunction<Run> durationFunction) {
         return durationFunction(runs, preFilter, durationFunction, LongStream::average);
     }
 
-    static Optional<Duration> stdDevDuration(List<? extends Run> runs, Predicate<Run> preFilter, ToLongFunction<Run> durationFunction) {
-        return durationFunction(runs, preFilter, durationFunction, longStream -> MathCommons.standardDeviation(longStream.boxed().collect(Collectors.toList())));
+    static Optional<Duration> stdDevDuration(
+            List<? extends Run> runs, Predicate<Run> preFilter, ToLongFunction<Run> durationFunction) {
+        return durationFunction(
+                runs,
+                preFilter,
+                durationFunction,
+                longStream -> MathCommons.standardDeviation(longStream.boxed().collect(Collectors.toList())));
     }
 
-    private static Optional<Duration> durationFunction(List<? extends Run> runs, Predicate<Run> preFilter, ToLongFunction<Run> durationFunction, Function<LongStream, OptionalDouble> durationCollector) {
+    private static Optional<Duration> durationFunction(
+            List<? extends Run> runs,
+            Predicate<Run> preFilter,
+            ToLongFunction<Run> durationFunction,
+            Function<LongStream, OptionalDouble> durationCollector) {
         LongStream longStream = preFilter(runs, preFilter)
                 .filter(r -> durationFunction.applyAsLong(r) > 0)
                 .mapToLong(durationFunction);
@@ -123,8 +134,6 @@ class Utils {
     }
 
     private static Stream<? extends Run> preFilter(List<? extends Run> runs, Predicate<Run> preFilter) {
-        return runs.stream()
-                .filter(preFilter);
+        return runs.stream().filter(preFilter);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/AvgCheckoutDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/AvgCheckoutDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.FreeStyleProject;
 import hudson.model.ListView;
@@ -34,12 +40,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class AvgCheckoutDurationColumnTest {
     @ClassRule
@@ -103,11 +103,16 @@ public class AvgCheckoutDurationColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", avgCheckoutDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", avgCheckoutDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), avgCheckoutDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    avgCheckoutDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -120,11 +125,16 @@ public class AvgCheckoutDurationColumnTest {
         project.setDefinition(checkoutDefinition());
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", avgCheckoutDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", avgCheckoutDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), avgCheckoutDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    avgCheckoutDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/AvgDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/AvgDurationColumnTest.java
@@ -24,6 +24,13 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -32,13 +39,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class AvgDurationColumnTest {
     @ClassRule
@@ -107,7 +107,8 @@ public class AvgDurationColumnTest {
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), avgDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), avgDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -124,7 +125,8 @@ public class AvgDurationColumnTest {
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), avgDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), avgDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec
@@ -133,5 +135,4 @@ public class AvgDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/AvgSuccessDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/AvgSuccessDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -32,12 +38,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class AvgSuccessDurationColumnTest {
     @ClassRule
@@ -89,11 +89,16 @@ public class AvgSuccessDurationColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", avgSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", avgSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), avgSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    avgSuccessDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -106,11 +111,16 @@ public class AvgSuccessDurationColumnTest {
         project.setDefinition(sleepDefinition(1));
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", avgSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", avgSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), avgSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    avgSuccessDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec
@@ -119,5 +129,4 @@ public class AvgSuccessDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/BuildingRunsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/BuildingRunsTest.java
@@ -24,7 +24,17 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.slowDefinition;
+import static org.jenkinsci.plugins.additionalmetrics.Utilities.getColumns;
+import static org.jenkinsci.plugins.additionalmetrics.Utilities.getMetricMethod;
+import static org.junit.Assert.assertNull;
+
 import hudson.views.ListViewColumn;
+import java.lang.reflect.Method;
+import java.util.Collection;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.AfterClass;
@@ -36,17 +46,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.lang.reflect.Method;
-import java.util.Collection;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.slowDefinition;
-import static org.jenkinsci.plugins.additionalmetrics.Utilities.getColumns;
-import static org.jenkinsci.plugins.additionalmetrics.Utilities.getMetricMethod;
-import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 public class BuildingRunsTest {
@@ -89,5 +88,4 @@ public class BuildingRunsTest {
 
         assertNull(res);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/FailureRateColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/FailureRateColumnTest.java
@@ -24,6 +24,10 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.assertEquals;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -31,10 +35,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.assertEquals;
 
 public class FailureRateColumnTest {
     @ClassRule
@@ -79,7 +79,8 @@ public class FailureRateColumnTest {
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), failureRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), failureRateColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -96,11 +97,11 @@ public class FailureRateColumnTest {
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), failureRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), failureRateColumn.getColumnCaption());
         }
 
         assertEquals("100.00%", columnNode.asNormalizedText());
         assertEquals("1.0", dataOf(columnNode));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/FailureTimeRateColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/FailureTimeRateColumnTest.java
@@ -24,14 +24,6 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
-import com.gargoylesoftware.htmlunit.html.DomNode;
-import hudson.model.ListView;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
@@ -39,6 +31,14 @@ import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.failin
 import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.successDefinition;
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
 import static org.junit.Assert.assertEquals;
+
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import hudson.model.ListView;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public class FailureTimeRateColumnTest {
     @ClassRule
@@ -92,11 +92,13 @@ public class FailureTimeRateColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", failureTimeRateColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", failureTimeRateColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), failureTimeRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), failureTimeRateColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -109,15 +111,16 @@ public class FailureTimeRateColumnTest {
         project.setDefinition(failingDefinition());
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", failureTimeRateColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", failureTimeRateColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), failureTimeRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), failureTimeRateColumn.getColumnCaption());
         }
 
         assertEquals("100.00%", columnNode.asNormalizedText());
         assertEquals("1.0", dataOf(columnNode));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/MaxCheckoutDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/MaxCheckoutDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.FreeStyleProject;
 import hudson.model.ListView;
@@ -36,12 +42,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.SleepBuilder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class MaxCheckoutDurationColumnTest {
     @ClassRule
@@ -103,11 +103,16 @@ public class MaxCheckoutDurationColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", maxCheckoutDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", maxCheckoutDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), maxCheckoutDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    maxCheckoutDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -120,11 +125,16 @@ public class MaxCheckoutDurationColumnTest {
         project.setDefinition(checkoutDefinition());
         WorkflowRun run = project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", maxCheckoutDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", maxCheckoutDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), maxCheckoutDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    maxCheckoutDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec - #1
@@ -134,5 +144,4 @@ public class MaxCheckoutDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/MaxDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/MaxDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -33,12 +39,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class MaxDurationColumnTest {
     @ClassRule
@@ -107,7 +107,8 @@ public class MaxDurationColumnTest {
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), maxDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), maxDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -124,7 +125,8 @@ public class MaxDurationColumnTest {
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), maxDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), maxDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec - #1
@@ -134,5 +136,4 @@ public class MaxDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/MaxSuccessDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/MaxSuccessDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -33,12 +39,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class MaxSuccessDurationColumnTest {
     @ClassRule
@@ -90,11 +90,16 @@ public class MaxSuccessDurationColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", maxSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", maxSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), maxSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    maxSuccessDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -107,11 +112,16 @@ public class MaxSuccessDurationColumnTest {
         project.setDefinition(sleepDefinition(1));
         WorkflowRun run = project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", maxSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", maxSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), maxSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    maxSuccessDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec - #1
@@ -121,5 +131,4 @@ public class MaxSuccessDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/MetricsActionFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/MetricsActionFactoryTest.java
@@ -24,9 +24,17 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.checkoutDefinition;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.successDefinition;
+
 import com.gargoylesoftware.htmlunit.html.DomElement;
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import com.gargoylesoftware.htmlunit.xml.XmlPage;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -35,15 +43,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.xml.sax.SAXException;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.checkoutDefinition;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.successDefinition;
 
 public class MetricsActionFactoryTest {
     @ClassRule
@@ -54,78 +53,112 @@ public class MetricsActionFactoryTest {
         jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuilds");
 
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            XmlPage xmlPage = webClient.goToXml("api/xml?depth=3&xpath=/hudson/job[name='ProjectWithZeroBuilds']/action/jobMetrics");
+            XmlPage xmlPage = webClient.goToXml(
+                    "api/xml?depth=3&xpath=/hudson/job[name='ProjectWithZeroBuilds']/action/jobMetrics");
 
             Map<String, String> metrics = childrenAsMap(xmlPage.getDocumentElement());
 
-            assertThat(metrics,
-                    match("avgCheckoutDuration", isEqualTo(0),
-                            "avgDuration", isEqualTo(0),
-                            "avgSuccessDuration", isEqualTo(0),
-                            "failureRate", isEqualTo(0.0),
-                            "failureTimeRate", isEqualTo(0.0),
-                            "maxCheckoutDuration", isEqualTo(0),
-                            "maxDuration", isEqualTo(0),
-                            "maxSuccessDuration", isEqualTo(0),
-                            "minCheckoutDuration", isEqualTo(0),
-                            "minDuration", isEqualTo(0),
-                            "minSuccessDuration", isEqualTo(0),
-                            "successRate", isEqualTo(0.0),
-                            "successTimeRate", isEqualTo(0.0),
-                            "standardDeviationDuration", isEqualTo(0),
-                            "standardDeviationSuccessDuration", isEqualTo(0)
-                    )
-            );
+            assertThat(
+                    metrics,
+                    match(
+                            "avgCheckoutDuration",
+                            isEqualTo(0),
+                            "avgDuration",
+                            isEqualTo(0),
+                            "avgSuccessDuration",
+                            isEqualTo(0),
+                            "failureRate",
+                            isEqualTo(0.0),
+                            "failureTimeRate",
+                            isEqualTo(0.0),
+                            "maxCheckoutDuration",
+                            isEqualTo(0),
+                            "maxDuration",
+                            isEqualTo(0),
+                            "maxSuccessDuration",
+                            isEqualTo(0),
+                            "minCheckoutDuration",
+                            isEqualTo(0),
+                            "minDuration",
+                            isEqualTo(0),
+                            "minSuccessDuration",
+                            isEqualTo(0),
+                            "successRate",
+                            isEqualTo(0.0),
+                            "successTimeRate",
+                            isEqualTo(0.0),
+                            "standardDeviationDuration",
+                            isEqualTo(0),
+                            "standardDeviationSuccessDuration",
+                            isEqualTo(0)));
         }
     }
 
     @Test
-    public void one_run_should_have_appropriate_metrics() throws IOException, SAXException, ExecutionException, InterruptedException {
+    public void one_run_should_have_appropriate_metrics()
+            throws IOException, SAXException, ExecutionException, InterruptedException {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithOneSuccessBuild");
         project.setDefinition(successDefinition());
         project.scheduleBuild2(0).get();
 
-
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            XmlPage xmlPage = webClient.goToXml("api/xml?depth=3&xpath=/hudson/job[name='ProjectWithOneSuccessBuild']/action/jobMetrics");
+            XmlPage xmlPage = webClient.goToXml(
+                    "api/xml?depth=3&xpath=/hudson/job[name='ProjectWithOneSuccessBuild']/action/jobMetrics");
 
             Map<String, String> metrics = childrenAsMap(xmlPage.getDocumentElement());
 
-            assertThat(metrics,
-                    match("avgDuration", isGreaterThan(0),
-                            "avgSuccessDuration", isGreaterThan(0),
-                            "failureRate", isEqualTo(0.0),
-                            "failureTimeRate", isEqualTo(0.0),
-                            "maxDuration", isGreaterThan(0),
-                            "maxSuccessDuration", isGreaterThan(0),
-                            "minDuration", isGreaterThan(0),
-                            "minSuccessDuration", isGreaterThan(0),
-                            "successRate", isEqualTo(1.0),
-                            "successTimeRate", isEqualTo(1.0),
-                            "standardDeviationDuration", isEqualTo(0),
-                            "standardDeviationSuccessDuration", isEqualTo(0)
-                    )
-            );
+            assertThat(
+                    metrics,
+                    match(
+                            "avgDuration",
+                            isGreaterThan(0),
+                            "avgSuccessDuration",
+                            isGreaterThan(0),
+                            "failureRate",
+                            isEqualTo(0.0),
+                            "failureTimeRate",
+                            isEqualTo(0.0),
+                            "maxDuration",
+                            isGreaterThan(0),
+                            "maxSuccessDuration",
+                            isGreaterThan(0),
+                            "minDuration",
+                            isGreaterThan(0),
+                            "minSuccessDuration",
+                            isGreaterThan(0),
+                            "successRate",
+                            isEqualTo(1.0),
+                            "successTimeRate",
+                            isEqualTo(1.0),
+                            "standardDeviationDuration",
+                            isEqualTo(0),
+                            "standardDeviationSuccessDuration",
+                            isEqualTo(0)));
         }
     }
 
     @Test
-    public void one_checkout_run_should_have_checkout_metrics() throws IOException, SAXException, ExecutionException, InterruptedException {
+    public void one_checkout_run_should_have_checkout_metrics()
+            throws IOException, SAXException, ExecutionException, InterruptedException {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithOneCheckoutBuild");
         project.setDefinition(checkoutDefinition());
         project.scheduleBuild2(0).get();
 
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            XmlPage xmlPage = webClient.goToXml("api/xml?depth=3&xpath=/hudson/job[name='ProjectWithOneCheckoutBuild']/action/jobMetrics");
+            XmlPage xmlPage = webClient.goToXml(
+                    "api/xml?depth=3&xpath=/hudson/job[name='ProjectWithOneCheckoutBuild']/action/jobMetrics");
 
             Map<String, String> metrics = childrenAsMap(xmlPage.getDocumentElement());
 
-            assertThat(metrics,
-                    match("avgCheckoutDuration", isGreaterThan(0),
-                            "minCheckoutDuration", isGreaterThan(0),
-                            "maxCheckoutDuration", isGreaterThan(0)
-                    )
-            );
+            assertThat(
+                    metrics,
+                    match(
+                            "avgCheckoutDuration",
+                            isGreaterThan(0),
+                            "minCheckoutDuration",
+                            isGreaterThan(0),
+                            "maxCheckoutDuration",
+                            isGreaterThan(0)));
         }
     }
 
@@ -173,8 +206,7 @@ public class MetricsActionFactoryTest {
             }
 
             @Override
-            public void describeTo(Description description) {
-            }
+            public void describeTo(Description description) {}
         };
     }
 
@@ -187,5 +219,4 @@ public class MetricsActionFactoryTest {
 
         return elements;
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/MinCheckoutDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/MinCheckoutDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.FreeStyleProject;
 import hudson.model.ListView;
@@ -36,12 +42,6 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.SleepBuilder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class MinCheckoutDurationColumnTest {
     @ClassRule
@@ -103,11 +103,16 @@ public class MinCheckoutDurationColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", minCheckoutDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", minCheckoutDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), minCheckoutDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    minCheckoutDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -120,11 +125,16 @@ public class MinCheckoutDurationColumnTest {
         project.setDefinition(checkoutDefinition());
         WorkflowRun run = project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", minCheckoutDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", minCheckoutDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), minCheckoutDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    minCheckoutDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec - #1
@@ -134,5 +144,4 @@ public class MinCheckoutDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/MinDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/MinDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -33,12 +39,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class MinDurationColumnTest {
     @ClassRule
@@ -107,7 +107,8 @@ public class MinDurationColumnTest {
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), minDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), minDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -124,7 +125,8 @@ public class MinDurationColumnTest {
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), minDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), minDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec - #1
@@ -134,5 +136,4 @@ public class MinDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/MinSuccessDurationColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/MinSuccessDurationColumnTest.java
@@ -24,6 +24,12 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.*;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -33,12 +39,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.*;
 
 public class MinSuccessDurationColumnTest {
     @ClassRule
@@ -90,11 +90,16 @@ public class MinSuccessDurationColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", minSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", minSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), minSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    minSuccessDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -107,11 +112,16 @@ public class MinSuccessDurationColumnTest {
         project.setDefinition(sleepDefinition(1));
         WorkflowRun run = project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", minSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", minSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), minSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    minSuccessDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec - #1
@@ -121,5 +131,4 @@ public class MinSuccessDurationColumnTest {
 
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/NoRunsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/NoRunsTest.java
@@ -24,7 +24,16 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.jenkinsci.plugins.additionalmetrics.Utilities.getColumns;
+import static org.jenkinsci.plugins.additionalmetrics.Utilities.getMetricMethod;
+import static org.junit.Assert.assertNull;
+
 import hudson.views.ListViewColumn;
+import java.lang.reflect.Method;
+import java.util.Collection;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -34,16 +43,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.lang.reflect.Method;
-import java.util.Collection;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.not;
-import static org.jenkinsci.plugins.additionalmetrics.Utilities.getColumns;
-import static org.jenkinsci.plugins.additionalmetrics.Utilities.getMetricMethod;
-import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 public class NoRunsTest {
@@ -76,5 +75,4 @@ public class NoRunsTest {
 
         assertNull(res);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/PipelineDefinitions.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/PipelineDefinitions.java
@@ -28,7 +28,8 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 
 class PipelineDefinitions {
 
-    private static final String CHECKOUT = "checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/jenkinsci/additional-metrics-plugin.git']]])";
+    private static final String CHECKOUT =
+            "checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/jenkinsci/additional-metrics-plugin.git']]])";
     private static final String FAILURE = "ech";
     private static final String UNSTABLE = "currentBuild.result = 'UNSTABLE'";
 
@@ -71,5 +72,4 @@ class PipelineDefinitions {
     static CpsFlowDefinition slowDefinition() {
         return sleepDefinition(60);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/RateStringParameterizedTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/RateStringParameterizedTest.java
@@ -24,15 +24,13 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class RateStringParameterizedTest {
@@ -47,15 +45,13 @@ public class RateStringParameterizedTest {
 
     @Parameters(name = "{index}: rate[{0}]={1}")
     public static Iterable<Object[]> data() {
-        return Arrays.asList(
-                new Object[][]{
-                        {0, "0.00%"},
-                        {0.333333, "33.33%"},
-                        {0.5, "50.00%"},
-                        {0.666667, "66.67%"},
-                        {1, "100.00%"},
-                }
-        );
+        return Arrays.asList(new Object[][] {
+            {0, "0.00%"},
+            {0.333333, "33.33%"},
+            {0.5, "50.00%"},
+            {0.666667, "66.67%"},
+            {1, "100.00%"},
+        });
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/StdevDurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/StdevDurationTest.java
@@ -24,9 +24,6 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
-import com.gargoylesoftware.htmlunit.html.DomNode;
-import com.google.common.collect.ImmutableList;
-import hudson.model.ListView;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.sleepDefinition;
@@ -34,15 +31,18 @@ import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.sleepT
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.createAndAddListView;
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.dataOf;
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.getListViewCell;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import com.google.common.collect.ImmutableList;
+import hudson.model.ListView;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
 
 public class StdevDurationTest {
 
@@ -65,8 +65,10 @@ public class StdevDurationTest {
         WorkflowRun run2 = project.scheduleBuild2(0).get();
 
         Duration stdevDuration = stdevDurationColumn.getStdevDuration(project);
-        assertEquals((long) MathCommons.standardDeviation(ImmutableList.of(run1.getDuration(), run2.getDuration())).getAsDouble(), stdevDuration.getAsLong());
-
+        assertEquals(
+                (long) MathCommons.standardDeviation(ImmutableList.of(run1.getDuration(), run2.getDuration()))
+                        .getAsDouble(),
+                stdevDuration.getAsLong());
     }
 
     @Test
@@ -78,18 +80,23 @@ public class StdevDurationTest {
         WorkflowRun run2 = project.scheduleBuild2(0).get();
 
         Duration stdevDuration = stdevDurationColumn.getStdevDuration(project);
-        assertEquals((long) MathCommons.standardDeviation(ImmutableList.of(run1.getDuration(), run2.getDuration())).getAsDouble(), stdevDuration.getAsLong());
+        assertEquals(
+                (long) MathCommons.standardDeviation(ImmutableList.of(run1.getDuration(), run2.getDuration()))
+                        .getAsDouble(),
+                stdevDuration.getAsLong());
     }
 
     @Test
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", stdevDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", stdevDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), stdevDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), stdevDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -102,11 +109,13 @@ public class StdevDurationTest {
         project.setDefinition(sleepDefinition(1));
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", stdevDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", stdevDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), stdevDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), stdevDurationColumn.getColumnCaption());
         }
 
         assertEquals("0 ms", columnNode.asNormalizedText());
@@ -121,11 +130,13 @@ public class StdevDurationTest {
         project.setDefinition(sleepDefinition(3));
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListTwoRuns", stdevDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListTwoRuns", stdevDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), stdevDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), stdevDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/StdevSuccessDurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/StdevSuccessDurationTest.java
@@ -24,9 +24,6 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
-import com.gargoylesoftware.htmlunit.html.DomNode;
-import com.google.common.collect.ImmutableList;
-import hudson.model.ListView;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.failingDefinition;
@@ -35,16 +32,19 @@ import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.unstab
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.createAndAddListView;
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.dataOf;
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.getListViewCell;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import com.google.common.collect.ImmutableList;
+import hudson.model.ListView;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
 
 public class StdevSuccessDurationTest {
 
@@ -67,8 +67,10 @@ public class StdevSuccessDurationTest {
         WorkflowRun run2 = project.scheduleBuild2(0).get();
 
         Duration stdevDuration = stdevSuccessDurationColumn.getStdevSuccessDuration(project);
-        assertEquals((long) MathCommons.standardDeviation(ImmutableList.of(run1.getDuration(), run2.getDuration())).getAsDouble()
-                , stdevDuration.getAsLong());
+        assertEquals(
+                (long) MathCommons.standardDeviation(ImmutableList.of(run1.getDuration(), run2.getDuration()))
+                        .getAsDouble(),
+                stdevDuration.getAsLong());
     }
 
     @Test
@@ -95,11 +97,16 @@ public class StdevSuccessDurationTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", stdevSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", stdevSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), stdevSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    stdevSuccessDurationColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -112,11 +119,16 @@ public class StdevSuccessDurationTest {
         project.setDefinition(sleepDefinition(1));
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", stdevSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", stdevSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), stdevSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    stdevSuccessDurationColumn.getColumnCaption());
         }
 
         assertEquals("0 ms", columnNode.asNormalizedText());
@@ -131,11 +143,16 @@ public class StdevSuccessDurationTest {
         project.setDefinition(sleepDefinition(3));
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListTwoRuns", stdevSuccessDurationColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListTwoRuns", stdevSuccessDurationColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), stdevSuccessDurationColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView),
+                    listView,
+                    project.getName(),
+                    stdevSuccessDurationColumn.getColumnCaption());
         }
 
         // sample output: 1.1 sec
@@ -143,6 +160,4 @@ public class StdevSuccessDurationTest {
         assertTrue(text.contains("sec"));
         assertThat(Long.parseLong(dataOf(columnNode)), greaterThan(0L));
     }
-
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/SuccessRateColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/SuccessRateColumnTest.java
@@ -24,6 +24,10 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
+import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
+import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
+import static org.junit.Assert.assertEquals;
+
 import com.gargoylesoftware.htmlunit.html.DomNode;
 import hudson.model.ListView;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -31,10 +35,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.*;
-import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
-import static org.junit.Assert.assertEquals;
 
 public class SuccessRateColumnTest {
     @ClassRule
@@ -79,7 +79,8 @@ public class SuccessRateColumnTest {
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), successRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), successRateColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -96,11 +97,11 @@ public class SuccessRateColumnTest {
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), successRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), successRateColumn.getColumnCaption());
         }
 
         assertEquals("100.00%", columnNode.asNormalizedText());
         assertEquals("1.0", dataOf(columnNode));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/SuccessTimeRateColumnTest.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/SuccessTimeRateColumnTest.java
@@ -24,14 +24,6 @@
 
 package org.jenkinsci.plugins.additionalmetrics;
 
-import com.gargoylesoftware.htmlunit.html.DomNode;
-import hudson.model.ListView;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
@@ -39,6 +31,14 @@ import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.failin
 import static org.jenkinsci.plugins.additionalmetrics.PipelineDefinitions.successDefinition;
 import static org.jenkinsci.plugins.additionalmetrics.UIHelpers.*;
 import static org.junit.Assert.assertEquals;
+
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import hudson.model.ListView;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public class SuccessTimeRateColumnTest {
     @ClassRule
@@ -92,11 +92,13 @@ public class SuccessTimeRateColumnTest {
     public void no_runs_should_display_as_NA_in_UI() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class, "ProjectWithZeroBuildsForUI");
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", successTimeRateColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListNoRuns", successTimeRateColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), successTimeRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), successTimeRateColumn.getColumnCaption());
         }
 
         assertEquals("N/A", columnNode.asNormalizedText());
@@ -109,15 +111,16 @@ public class SuccessTimeRateColumnTest {
         project.setDefinition(successDefinition());
         project.scheduleBuild2(0).get();
 
-        ListView listView = createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", successTimeRateColumn, project);
+        ListView listView =
+                createAndAddListView(jenkinsRule.getInstance(), "MyListOneRun", successTimeRateColumn, project);
 
         DomNode columnNode;
         try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
-            columnNode = getListViewCell(webClient.getPage(listView), listView, project.getName(), successTimeRateColumn.getColumnCaption());
+            columnNode = getListViewCell(
+                    webClient.getPage(listView), listView, project.getName(), successTimeRateColumn.getColumnCaption());
         }
 
         assertEquals("100.00%", columnNode.asNormalizedText());
         assertEquals("1.0", dataOf(columnNode));
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/UIHelpers.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/UIHelpers.java
@@ -30,11 +30,10 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.ListView;
 import hudson.model.TopLevelItem;
 import hudson.views.ListViewColumn;
-import jenkins.model.Jenkins;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import jenkins.model.Jenkins;
 
 class UIHelpers {
 
@@ -55,7 +54,8 @@ class UIHelpers {
         return td;
     }
 
-    static ListView createAndAddListView(Jenkins instance, String listName, ListViewColumn column, TopLevelItem job) throws IOException {
+    static ListView createAndAddListView(Jenkins instance, String listName, ListViewColumn column, TopLevelItem job)
+            throws IOException {
         ListView listView = new ListView(listName, instance);
         listView.getColumns().add(column);
         listView.add(job);

--- a/src/test/java/org/jenkinsci/plugins/additionalmetrics/Utilities.java
+++ b/src/test/java/org/jenkinsci/plugins/additionalmetrics/Utilities.java
@@ -26,15 +26,14 @@ package org.jenkinsci.plugins.additionalmetrics;
 
 import com.google.common.collect.Iterables;
 import hudson.views.ListViewColumn;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Set;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.reflections.Reflections;
 import org.reflections.scanners.Scanners;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
-
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.Set;
 
 class Utilities {
     static void terminateWorkflowRun(WorkflowRun workflowRun) {
@@ -45,8 +44,8 @@ class Utilities {
     static Collection<Class<? extends ListViewColumn>> getColumns() {
         String packagePath = BuildingRunsTest.class.getPackage().getName();
 
-        Reflections reflections = new Reflections(new ConfigurationBuilder()
-                .setUrls(ClasspathHelper.forPackage(packagePath)));
+        Reflections reflections =
+                new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(packagePath)));
 
         return reflections.getSubTypesOf(ListViewColumn.class);
     }


### PR DESCRIPTION
See https://github.com/jenkinsci/plugin-pom/pull/733 for background. In that PR we have introduced a new project-wide Spotless configuration to which plugins can opt-in by creating a `.mvn_exec_spotless` file. This PR adopts that new upstream configuration in this repository while retaining the license header addition that is unique to this repository. While this is a subjective opinion, we feel there are benefits for adopting a project-wide standard; namely, consistency as one goes from one repository to the next and ease of onboarding of new developers. Plus, you won't have to maintain a Spotless configuration anymore, since the burden is now on the upstream core developers. Ultimately, you have the choice as to what standard you would like to follow, so I would not be upset if this PR were to be rejected. But if accepted, the next step after merging this PR would be to create a `.git-blame-ignore-revs` file so that this commit does not clutter up the Git blame view with unrelated formatting changes. CC @ChadiEM 